### PR TITLE
Japanese translations have been added.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+# Japanese strings go here
+ja:
+  label_avatar: "アバター"
+  message_avatar_uploaded: "アバターのアップロードに成功しました。"
+  button_change_avatar:  "アバターの変更"
+  are_you_sure_delete_avatar: "アバターを削除してもよろしいですか？"
+  avatar_deleted:  "アバターは削除されました。"
+  unable_to_delete_avatar:  "アバターの削除中にエラーが発生しました。"


### PR DESCRIPTION
This commit make the plugin shows strings in Japanese.
Added a locale file ja.yml and checked with Redmine 2.6.5.
I think it was pretty fine.