### PR TITLE
Change avator path to relative

### DIFF
--- a/lib/application_helper_avatar_patch.rb
+++ b/lib/application_helper_avatar_patch.rb
@@ -30,7 +30,7 @@ module LocalAvatarsPlugin
 			if user.is_a?(User)then
 				av = user.attachments.find_by_description 'avatar'
 				if av then
-					image_url = url_for :only_path => false, :controller => 'account', :action => 'get_avatar', :id => user
+					image_url = url_for :only_path => true, :controller => 'account', :action => 'get_avatar', :id => user
 					options[:size] = "64" unless options[:size]
 					return "<img class=\"gravatar\" width=\"#{options[:size]}\" height=\"#{options[:size]}\" src=\"#{image_url}\" />".html_safe
 				end


### PR DESCRIPTION
Redmine can't show avator under reverse proxy.
So change absolute path to relative path.

e.g. Redmine root path = http://example.com/redmine
✕ http://redmine/redmine/account/get_avatar/8
◯ /redmine/account/get_avatar/8 (http://example.com/redmine/account/get_avatar/8)