### PR TITLE
[TASK] Private avatars, cachable avatars

### DIFF
--- a/lib/local_avatars.rb
+++ b/lib/local_avatars.rb
@@ -19,10 +19,15 @@
 module LocalAvatarsPlugin
 	module LocalAvatars
 		def send_avatar(user)
-			av = user.attachments.find_by_description 'avatar'
-			send_file(av.diskfile, :filename => filename_for_content_disposition(av.filename),
-			                       :type => av.content_type, 
-			                       :disposition => (av.image? ? 'inline' : 'attachment')) if av 
+			if User.current.login.length > 0 then
+                		av = user.attachments.find_by_description 'avatar'
+                		send_file(av.diskfile, :filename => filename_for_content_disposition(av.filename),
+							:type => av.content_type,
+							:disposition => (av.image? ? 'inline' : 'attachment')) if av
+				response.headers['Cache-Control'] = 'public, max-age=86400';
+			else
+				response.headers['X-Status-Reason'] = 'no login'
+		    	end
 		end
 
 		# expects @user to be set.


### PR DESCRIPTION
I'm a total ruby-newby but I think this can be a workable approach to only return avatars when a user is logged in.

Also I found out that avatars are sent uncached and retrieved time and again, so I added a Cache-Control header. The reason for having it private was related to IE6-issues, which I think can nowadays be totally ignored.

This  addresses issues #26 and #23.

(One thing remaining I could not work out was to make the avatar plugin return resized images - if someone uploads a 5MB jpeg, this one is send and scaled to 64x64 only by the browser)

Thanks for your plugin, I hope the contribution is helpful.