### PR TITLE
Fix route for Redmine6.1 OAuth

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do 
     match 'my/avatar', :to => 'my#avatar', :via => [:get, :post]
     match 'my/save_avatar/:id', :to => 'my#save_avatar', :via => [:get, :post]
-    match 'account/get_avatar/:id', :to => 'account#get_avatar', :constraints => {:id=>/\d+/}, :via => [:get, :post]
+    match 'account/get_avatar/:id', :to => 'account#get_avatar', :constraints => {:id=>/\d+/}, :via => [:get, :post], as: :local_avatar
     match 'users/save_avatar/:id', :to => 'users#save_avatar', :constraints => {:id=>/\d+/}, :via => [:get, :post]
     match 'users/get_avatar/:id', :to => 'users#get_avatar', :constraints => {:id=>/\d+/}, :via => [:get, :post]
 end

--- a/lib/application_helper_avatar_patch.rb
+++ b/lib/application_helper_avatar_patch.rb
@@ -31,7 +31,7 @@
 			if user.is_a?(User)then
 				av = user.attachments.find_by_description 'avatar'
 				if av then
-					image_url = url_for :only_path => true, :controller => '/account', :action => 'get_avatar', :id => user
+					image_url = local_avatar_path(user)
 					options[:size] = "24" unless options[:size]
 					title = "#{user.name}"
 					return "<img class=\"gravatar\" title=\"#{title}\" width=\"#{options[:size]}\" height=\"#{options[:size]}\" src=\"#{image_url}\" />".html_safe

--- a/lib/application_helper_avatar_patch.rb
+++ b/lib/application_helper_avatar_patch.rb
@@ -31,7 +31,7 @@
 			if user.is_a?(User)then
 				av = user.attachments.find_by_description 'avatar'
 				if av then
-					image_url = url_for :only_path => true, :controller => 'account', :action => 'get_avatar', :id => user
+					image_url = url_for :only_path => true, :controller => '/account', :action => 'get_avatar', :id => user.id.to_s
 					options[:size] = "24" unless options[:size]
 					title = "#{user.name}"
 					return "<img class=\"gravatar\" title=\"#{title}\" width=\"#{options[:size]}\" height=\"#{options[:size]}\" src=\"#{image_url}\" />".html_safe

--- a/lib/application_helper_avatar_patch.rb
+++ b/lib/application_helper_avatar_patch.rb
@@ -31,7 +31,7 @@
 			if user.is_a?(User)then
 				av = user.attachments.find_by_description 'avatar'
 				if av then
-					image_url = url_for :only_path => true, :controller => '/account', :action => 'get_avatar', :id => user.id.to_s
+					image_url = url_for :only_path => true, :controller => '/account', :action => 'get_avatar', :id => user
 					options[:size] = "24" unless options[:size]
 					title = "#{user.name}"
 					return "<img class=\"gravatar\" title=\"#{title}\" width=\"#{options[:size]}\" height=\"#{options[:size]}\" src=\"#{image_url}\" />".html_safe


### PR DESCRIPTION
Redmine 6.1 contains OAuth through doorkeeper gem. This creates a few new pages that attempt to render the avatar. These routes are currently broken.

I am not a ruby expert, but it seems patchable by changing one line.

---

**steps to reproduce**
* have Redmine 6.1
* have REST API enabled
* add a avatar image through this plugin
* click My Account > Authorized Applications
=> crashes with a 500

<details>
<summary>Log Output (Expand to View)</summary>

```
redmine-1  | I, [2026-02-26T19:48:36.152396 #1]  INFO -- : [3907abde-23b2-432f-8c04-b9a2b40abe33] Started GET "/oauth/authorized_applications" for 172.18.0.1 at 2026-02-26 19:48:36 +0000
redmine-1  | I, [2026-02-26T19:48:36.152896 #1]  INFO -- : [3907abde-23b2-432f-8c04-b9a2b40abe33] Processing by Doorkeeper::AuthorizedApplicationsController#index as HTML
redmine-1  | I, [2026-02-26T19:48:36.154798 #1]  INFO -- : [3907abde-23b2-432f-8c04-b9a2b40abe33]   Current user: admin (id=1)
redmine-1  | I, [2026-02-26T19:48:36.159882 #1]  INFO -- : [3907abde-23b2-432f-8c04-b9a2b40abe33]   Rendered layout layouts/base.html.erb (Duration: 4.5ms | GC: 0.3ms)
redmine-1  | I, [2026-02-26T19:48:36.160012 #1]  INFO -- : [3907abde-23b2-432f-8c04-b9a2b40abe33] Completed 500 Internal Server Error in 7ms (ActiveRecord: 1.2ms (9 queries, 0 cached) | GC: 0.3ms)
redmine-1  | F, [2026-02-26T19:48:36.160981 #1] FATAL -- : [3907abde-23b2-432f-8c04-b9a2b40abe33]   
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] ActionView::Template::Error (No route matches {action: "get_avatar", controller: "doorkeeper/account", id: #<User id: 1, login: "admin", hashed_password: [FILTERED], firstname: "Redmine", lastname: "Admin", admin: true, status: 1, last_login_on: "2026-02-26 19:46:52.000000000 +0000", language: "", auth_source_id: nil, created_on: "2026-02-26 19:46:09.000000000 +0000", updated_on: "2026-02-26 19:47:00.000000000 +0000", type: "User", mail_notification: "all", salt: "55d2c8717aaec669c2a20cd3b5ffa345", must_change_passwd: false, passwd_changed_on: "2026-02-26 19:47:00.000000000 +0000", twofa_scheme: nil, twofa_totp_key: nil, twofa_totp_last_used_at: nil, twofa_required: false>}):
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] 
redmine-1  | Causes:
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] ActionController::UrlGenerationError (No route matches {action: "get_avatar", controller: "doorkeeper/account", id: #<User id: 1, login: "admin", hashed_password: [FILTERED], firstname: "Redmine", lastname: "Admin", admin: true, status: 1, last_login_on: "2026-02-26 19:46:52.000000000 +0000", language: "", auth_source_id: nil, created_on: "2026-02-26 19:46:09.000000000 +0000", updated_on: "2026-02-26 19:47:00.000000000 +0000", type: "User", mail_notification: "all", salt: "55d2c8717aaec669c2a20cd3b5ffa345", must_change_passwd: false, passwd_changed_on: "2026-02-26 19:47:00.000000000 +0000", twofa_scheme: nil, twofa_totp_key: nil, twofa_totp_last_used_at: nil, twofa_required: false>})
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     36:     <% end %>
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     37: 
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     38:     <% if User.current.logged? %>
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     39:         <div class="flyout-menu__avatar">
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     40:           <%= link_to(avatar(User.current, :size => "40"), user_path(User.current)) %>
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     41:           <%= link_to_user(User.current, :format => :username) %>
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]     42:         </div>
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33]   
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] plugins/redmine_local_avatars/lib/application_helper_avatar_patch.rb:34:in 'ApplicationHelperAvatarPatch#avatar_with_local'
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] app/views/layouts/base.html.erb:39
redmine-1  | [3907abde-23b2-432f-8c04-b9a2b40abe33] lib/redmine/sudo_mode.rb:78:in 'Redmine::SudoMode::Controller#sudo_mode'
redmine-1  | I, [2026-02-26T19:48:36.232093 #1]  INFO -- : [d720c755-d068-44ea-b337-37561b37083a] Started GET "/favicon.ico" for 172.18.0.1 at 2026-02-26 19:48:36 +0000
redmine-1  | F, [2026-02-26T19:48:36.233086 #1] FATAL -- : [d720c755-d068-44ea-b337-37561b37083a]
```

</details>

Same thing happens if you log in through OAuth.
